### PR TITLE
Change to aligned AVX instructions

### DIFF
--- a/gates/kernels/apply_kernel_to_input_AVX.cpp
+++ b/gates/kernels/apply_kernel_to_input_AVX.cpp
@@ -79,8 +79,8 @@ apply_kernel_to_input_AVX_small(Matrix& u3_1qbit, Matrix& input, const bool& der
                 for (int col_idx = 0; col_idx < 2 * (input.cols - 1); col_idx = col_idx + 4) {
 
                     // extract successive elements from arrays element, element_pair
-                    __m256d element_vec = _mm256_loadu_pd(element + col_idx); // 6th register
-                    __m256d element_pair_vec = _mm256_loadu_pd(element_pair + col_idx); // 7th register
+                    __m256d element_vec = _mm256_load_pd(element + col_idx); // 6th register
+                    __m256d element_pair_vec = _mm256_load_pd(element_pair + col_idx); // 7th register
 
                     //// u3_1qbit_00*element_vec ////
 
@@ -122,7 +122,7 @@ apply_kernel_to_input_AVX_small(Matrix& u3_1qbit, Matrix& input, const bool& der
 
 
                     // 6 store the transformed elements in vec3
-                    _mm256_storeu_pd(element + col_idx, vec3);
+                    _mm256_store_pd(element + col_idx, vec3);
 
 
                     //// u3_1qbit_10*element_vec ////
@@ -152,7 +152,7 @@ apply_kernel_to_input_AVX_small(Matrix& u3_1qbit, Matrix& input, const bool& der
                     vec3 = _mm256_add_pd(vec3, vec5);
 
                     // 6 store the transformed elements in vec3
-                    _mm256_storeu_pd(element_pair + col_idx, vec3);
+                    _mm256_store_pd(element_pair + col_idx, vec3);
 
                 }
 
@@ -252,14 +252,14 @@ apply_kernel_to_input_AVX(Matrix& u3_1qbit, Matrix& input, const bool& deriv, co
                 for (int col_idx = 0; col_idx < 2 * (input.cols - 3); col_idx = col_idx + 8) {
 
                     // extract successive elements from arrays element, element_pair
-                    __m256d element_vec = _mm256_loadu_pd(element + col_idx);
-                    __m256d element_vec2 = _mm256_loadu_pd(element + col_idx + 4);
+                    __m256d element_vec = _mm256_load_pd(element + col_idx);
+                    __m256d element_vec2 = _mm256_load_pd(element + col_idx + 4);
                     __m256d tmp = _mm256_shuffle_pd(element_vec, element_vec2, 0);
                     element_vec2 = _mm256_shuffle_pd(element_vec, element_vec2, 0xf);
                     element_vec = tmp;
 
-                    __m256d element_pair_vec = _mm256_loadu_pd(element_pair + col_idx);
-                    __m256d element_pair_vec2 = _mm256_loadu_pd(element_pair + col_idx + 4);
+                    __m256d element_pair_vec = _mm256_load_pd(element_pair + col_idx);
+                    __m256d element_pair_vec2 = _mm256_load_pd(element_pair + col_idx + 4);
                     tmp = _mm256_shuffle_pd(element_pair_vec, element_pair_vec2, 0);
                     element_pair_vec2 = _mm256_shuffle_pd(element_pair_vec, element_pair_vec2, 0xf);
                     element_pair_vec = tmp;
@@ -279,8 +279,8 @@ apply_kernel_to_input_AVX(Matrix& u3_1qbit, Matrix& input, const bool& deriv, co
                     tmp = _mm256_shuffle_pd(vec3, vec5, 0);
                     vec5 = _mm256_shuffle_pd(vec3, vec5, 0xf);
                     vec3 = tmp;
-                    _mm256_storeu_pd(element + col_idx, vec3);
-                    _mm256_storeu_pd(element + col_idx + 4, vec5);
+                    _mm256_store_pd(element + col_idx, vec3);
+                    _mm256_store_pd(element + col_idx + 4, vec5);
 
                     __m256d vec7 = _mm256_mul_pd(u3_1bit_10r_vec, element_vec);
                     vec7 = _mm256_fnmadd_pd(u3_1bit_10i_vec, element_vec2, vec7);
@@ -297,8 +297,8 @@ apply_kernel_to_input_AVX(Matrix& u3_1qbit, Matrix& input, const bool& deriv, co
                     tmp = _mm256_shuffle_pd(vec7, vec9, 0);
                     vec9 = _mm256_shuffle_pd(vec7, vec9, 0xf);
                     vec7 = tmp;
-                    _mm256_storeu_pd(element_pair + col_idx, vec7);
-                    _mm256_storeu_pd(element_pair + col_idx + 4, vec9);
+                    _mm256_store_pd(element_pair + col_idx, vec7);
+                    _mm256_store_pd(element_pair + col_idx + 4, vec9);
                 }
 
                 int remainder = input.cols % 4;


### PR DESCRIPTION
GIven that AVX2 requires 16-byte alignment and:
1) matrix is aligned if owner=true
2) the smallest matrix is 2x2
3) the smallest unit read by AVX is 2 columns of real/imaginary doubles which is 16 bytes.

HOWEVER

if Matrix has its data come from a pre-allocated source.  All bets are off.  This can be easily fixed.

Proposal for that case: Add a matrix function ensure_aligned which if owner==false, copies the data.

The only issue is when owner=false and it is aligned e.g. the internal_owner vs external_owner.  So if the owner is another matrix class, vs if the owner were e.g. from the Python interface.  Regardless, the copying would not be inefficient in all use case scenarios as it would happen only once, on-demand when doing gate computations.