### PR TITLE
Remove bounds clamping from BFGS due to periodicity + better LBFGS limit

### DIFF
--- a/decomposition/N_Qubit_Decomposition_Base.cpp
+++ b/decomposition/N_Qubit_Decomposition_Base.cpp
@@ -1759,7 +1759,7 @@ void N_Qubit_Decomposition_Base::solve_layer_optimization_problem_BFGS( int num_
 	    
 
 
-            Problem p(num_of_parameters, 0, 2*M_PI, optimization_problem, optimization_problem_grad, optimization_problem_combined, (void*)this);
+            Problem p(num_of_parameters, -1e100, 1e100, optimization_problem, optimization_problem_grad, optimization_problem_combined, (void*)this);
 
             double f; 
             if (num_of_parameters > 250) {
@@ -1881,7 +1881,7 @@ bfgs_time = 0.0;
         for (long long iter_idx=0; iter_idx<iteration_loops_max; iter_idx++) {
 
             
-                Problem p(num_of_parameters, 0, 2*M_PI, optimization_problem, optimization_problem_grad, optimization_problem_combined, (void*)this);
+                Problem p(num_of_parameters, -1e100, 1e100, optimization_problem, optimization_problem_grad, optimization_problem_combined, (void*)this);
                 Tolmin tolmin(&p);
 
                 f = tolmin.Solve(solution_guess, false, max_inner_iterations);             

--- a/decomposition/N_Qubit_Decomposition_Base.cpp
+++ b/decomposition/N_Qubit_Decomposition_Base.cpp
@@ -1762,7 +1762,7 @@ void N_Qubit_Decomposition_Base::solve_layer_optimization_problem_BFGS( int num_
             Problem p(num_of_parameters, -1e100, 1e100, optimization_problem, optimization_problem_grad, optimization_problem_combined, (void*)this);
 
             double f; 
-            if (num_of_parameters > 250) {
+            if (num_of_parameters > 3168) {
                 Lbfgs lbfgs(&p);
                 f = lbfgs.Solve(solution_guess);
             } else {


### PR DESCRIPTION
Might need to fmod(x[i], 2*M_PI) on funmin calls if parameters values grow/shrink to the point of harming the precision of the double values.