### PR TITLE
Reduce slow sine/cosine usage in U3 gates + bad AVX parallel heuristic

### DIFF
--- a/gates/Gate.cpp
+++ b/gates/Gate.cpp
@@ -273,7 +273,7 @@ Gate::apply_kernel_to(Matrix& u3_1qbit, Matrix& input, bool deriv) {
         apply_kernel_to_input_AVX_small(u3_1qbit, input, deriv, target_qbit, control_qbit, matrix_size);
         return;
     }
-    else if ( qbit_num < 6 || (qbit_num < 10 && input.cols < 32) ) {
+    else if ( qbit_num < 10) {
         apply_kernel_to_input_AVX(u3_1qbit, input, deriv, target_qbit, control_qbit, matrix_size);
         return;
      }

--- a/gates/U3.cpp
+++ b/gates/U3.cpp
@@ -552,7 +552,7 @@ Matrix U3::calc_one_qubit_u3(double ThetaOver2, double Phi, double Lambda ) {
     u3_1qbit[0].imag = 0;
     // the 1,2 element
     u3_1qbit[1].real = -cos_lambda*sin_theta;
-    u3_1qbit[1].imag = -sin_Lambda*sin_theta;
+    u3_1qbit[1].imag = -sin_lambda*sin_theta;
     // the 2,1 element
     u3_1qbit[2].real = cos_phi*sin_theta;
     u3_1qbit[2].imag = sin_phi*sin_theta;

--- a/gates/U3.cpp
+++ b/gates/U3.cpp
@@ -542,20 +542,27 @@ Matrix U3::calc_one_qubit_u3(double ThetaOver2, double Phi, double Lambda ) {
 
     double cos_theta = cos(ThetaOver2);
     double sin_theta = sin(ThetaOver2);
-
+    double cos_phi = cos(Phi);
+    double sin_phi = sin(Phi);
+    double cos_lambda = cos(Lambda);
+    double sin_lambda = sin(Lambda);
 
     // the 1,1 element
     u3_1qbit[0].real = cos_theta;
     u3_1qbit[0].imag = 0;
     // the 1,2 element
-    u3_1qbit[1].real = -cos(Lambda)*sin_theta;
-    u3_1qbit[1].imag = -sin(Lambda)*sin_theta;
+    u3_1qbit[1].real = -cos_lambda*sin_theta;
+    u3_1qbit[1].imag = -sin_Lambda*sin_theta;
     // the 2,1 element
-    u3_1qbit[2].real = cos(Phi)*sin_theta;
-    u3_1qbit[2].imag = sin(Phi)*sin_theta;
+    u3_1qbit[2].real = cos_phi*sin_theta;
+    u3_1qbit[2].imag = sin_phi*sin_theta;
     // the 2,2 element
-    u3_1qbit[3].real = cos(Phi+Lambda)*cos_theta;
-    u3_1qbit[3].imag = sin(Phi+Lambda)*cos_theta;
+    //cos(a+b)=cos(a)cos(b)-sin(a)sin(b)
+    //sin(a+b)=sin(a)cos(b)+cos(a)sin(b)
+    u3_1qbit[3].real = (cos_phi*cos_lambda-sin_phi*sin_lambda)*cos_theta;
+    u3_1qbit[3].imag = (sin_phi*cos_lambda+cos_phi*sin_lambda)*cos_theta;
+    //u3_1qbit[3].real = cos(Phi+Lambda)*cos_theta;
+    //u3_1qbit[3].imag = sin(Phi+Lambda)*cos_theta;
 
 
     return u3_1qbit;


### PR DESCRIPTION
sine/cosine require hundreds of clock cycles, while multiplication and addition require only a few.