### PR TITLE
Change grad descend and BFGS error

### DIFF
--- a/common/grad_descend.cpp
+++ b/common/grad_descend.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-
+#include <cfloat>
 #include <grad_descend.h>
 
 
@@ -70,8 +70,8 @@ double Grad_Descend::Start_Optimization(Matrix_real &x, long maximal_iterations_
 
       
     // test for dimension
-    if ( variable_num <= 1 ) {
-        return 0.0;   
+    if ( variable_num <= 0 ) {
+        return DBL_MAX;   
     }
 
 

--- a/decomposition/N_Qubit_Decomposition_Base.cpp
+++ b/decomposition/N_Qubit_Decomposition_Base.cpp
@@ -1609,7 +1609,7 @@ void N_Qubit_Decomposition_Base::solve_layer_optimization_problem_GRAD_DESCEND( 
 	    
 
             Grad_Descend cGrad_Descend(optimization_problem_combined, this);
-            double f = cGrad_Descend.Start_Optimization(solution_guess, max_inner_iterations);
+            double f = cGrad_Descend.Start_Optimization(solution_guess, max_inner_iterations_loc);
 
             if (current_minimum > f) {
                 current_minimum = f;
@@ -2207,7 +2207,7 @@ void N_Qubit_Decomposition_Base::solve_layer_optimization_problem_BFGS( int num_
 	    
 
             BFGS_Powell cBFGS_Powell(optimization_problem_combined, this);
-            double f = cBFGS_Powell.Start_Optimization(solution_guess, max_inner_iterations);
+            double f = cBFGS_Powell.Start_Optimization(solution_guess, max_inner_iterations_loc);
 
             if (current_minimum > f) {
                 current_minimum = f;


### PR DESCRIPTION
Currently in BFGS and Grad_Descend, despite reading in max_inner_iterations from the config it still sets it to the default + fix in the parameter dimension check in Grad_Descend, that broke HS-test agents algorithm.