### PR TITLE
Fix Windows incompatibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-__pychache__
+__pycache__
 *.so
 *.pyc
+*.pyd
+*.manifest
+_skbuild/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,11 @@ __pycache__
 *.pyc
 *.pyd
 *.manifest
+*.binary
+*.egg
+*.dll
+*.so
+*.bat
 _skbuild/*
+squander.egg-info/*
+costfuncs_and_entropy.txt

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ $ python setup.py build_ext -DTBB_HEADER=<TBB_Location>\Library\include\
 
 Installation merely requires copying DLL files (if they are not in the path):
 
-$ copy _skbuild\win-amd64-3.9\cmake-install\bin .\qgd_python\decomposition
+$ copy _skbuild\win-amd64-3.9\cmake-install\bin .\squander\decomposition
 
-$ copy "%TBB_LOCATION%\Library\bin\tbb12.dll" .\qgd_python\decomposition
+$ copy "%TBB_LOCATION%\Library\bin\tbb12.dll" .\squander\decomposition
 
-$ copy "%TBB_LOCATION%\Library\bin\tbbmalloc.dll" .\qgd_python\decomposition
+$ copy "%TBB_LOCATION%\Library\bin\tbbmalloc.dll" .\squander\decomposition
 
 Verify the installation:
 

--- a/squander/decomposition/qgd_N_Qubit_Decomposition_adaptive_Wrapper.cpp
+++ b/squander/decomposition/qgd_N_Qubit_Decomposition_adaptive_Wrapper.cpp
@@ -2315,7 +2315,7 @@ qgd_N_Qubit_Decomposition_adaptive_Wrapper_get_Second_Renyi_Entropy( qgd_N_Qubit
 
 
     // check input argument qbit_list
-    if ( qubit_list_arg == NULL or (!PyList_Check( qubit_list_arg )) ) {
+    if ( qubit_list_arg == NULL || (!PyList_Check( qubit_list_arg )) ) {
         PyErr_SetString(PyExc_Exception, "qubit_list should be a list");
         return NULL;
     }

--- a/squander/gates/qgd_Circuit_Wrapper.cpp
+++ b/squander/gates/qgd_Circuit_Wrapper.cpp
@@ -889,7 +889,7 @@ qgd_Circuit_Wrapper_get_Second_Renyi_Entropy( qgd_Circuit_Wrapper *self, PyObjec
 
 
     // check input argument qbit_list
-    if ( qubit_list_arg == NULL or (!PyList_Check( qubit_list_arg )) ) {
+    if ( qubit_list_arg == NULL || (!PyList_Check( qubit_list_arg )) ) {
         PyErr_SetString(PyExc_Exception, "qubit_list should be a list");
         return NULL;
     }

--- a/squander/src-cpp/common/Bayes_Opt.cpp
+++ b/squander/src-cpp/common/Bayes_Opt.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <stdio.h>
 #include <stdlib.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <cfloat>
 #include <Bayes_Opt.h>

--- a/squander/src-cpp/common/grad_descend.cpp
+++ b/squander/src-cpp/common/grad_descend.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <stdio.h>
 #include <stdlib.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <cfloat>
 #include <grad_descend.h>

--- a/squander/src-cpp/gates/Gates_block.cpp
+++ b/squander/src-cpp/gates/Gates_block.cpp
@@ -50,7 +50,6 @@ limitations under the License.
 #endif
 
 
-
 //static tbb::spin_mutex my_mutex;
 /**
 @brief Default constructor of the class.
@@ -233,7 +232,11 @@ Gates_block::apply_to( Matrix_real& parameters_mtx, Matrix& input, bool parallel
 
                 Gates_block gates_block_mini = Gates_block(block_type[block_idx]);
                 std::vector<int> qbits = involved_qbits[block_idx];
+#ifdef _WIN32
+				int* indices = (int*)_malloca(qbit_num*sizeof(int));
+#else
                 int indices[qbit_num];
+#endif
 
                 for (int jdx=0; jdx<(int)qbits.size(); jdx++){
                     indices[qbits[jdx]]=jdx;

--- a/squander/variational_quantum_eigensolver/CMakeLists.txt
+++ b/squander/variational_quantum_eigensolver/CMakeLists.txt
@@ -3,7 +3,7 @@ set(EXT_DIR ${PROJECT_SOURCE_DIR}/squander/variational_quantum_eigensolver)
 
 
 add_library( qgd_Variational_Quantum_Eigensolver_Base_Wrapper MODULE
-    ${EXT_DIR}/qgd_Variational_Quantum_Eigensolver_Base_Wrapper.cpp
+    ${EXT_DIR}/qgd_VQE_Base_Wrapper.cpp
     ${PROJECT_SOURCE_DIR}/squander/src-cpp/common/numpy_interface.cpp        
 )
 

--- a/squander/variational_quantum_eigensolver/qgd_VQE_Base_Wrapper.cpp
+++ b/squander/variational_quantum_eigensolver/qgd_VQE_Base_Wrapper.cpp
@@ -988,7 +988,7 @@ qgd_Variational_Quantum_Eigensolver_Base_Wrapper_get_Second_Renyi_Entropy( qgd_V
 
 
     // check input argument qbit_list
-    if ( qubit_list_arg == NULL or (!PyList_Check( qubit_list_arg )) ) {
+    if ( qubit_list_arg == NULL || (!PyList_Check( qubit_list_arg )) ) {
         PyErr_SetString(PyExc_Exception, "qubit_list should be a list");
         return NULL;
     }


### PR DESCRIPTION
Note: long file paths due to not abbreviating Variational_Quantum_Eigensolver as VQE (which would be an improvement to the whole file and source code/class name structure) required renaming of a C++ file or MSVC hit the 260 character path limitation.

Also should avoid using the gcc stack allocated arrays ideally or _alloca/_malloca must be used.  But in general C does not support this even if gcc/Linux C libs and MSVC do...