### PR TITLE
Fix list gates parameters print order.

### DIFF
--- a/squander/src-cpp/gates/Gates_block.cpp
+++ b/squander/src-cpp/gates/Gates_block.cpp
@@ -1648,7 +1648,7 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
 	print(sstream, 1);	    	
 		
         int gate_idx = start_index;
-        int parameter_idx = parameter_num;
+        int parameter_idx = 0;
 	double *parameters_data = parameters.get_data();
 	//const_cast <Matrix_real&>(parameters);
 
@@ -1698,47 +1698,47 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
 
                 if ((u3_gate->get_parameter_num() == 1) && u3_gate->is_theta_parameter()) {
 		   
-                    vartheta = std::fmod( 2*parameters_data[parameter_idx-1], 4*M_PI);
+                    vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
                     varphi = 0;
                     varlambda =0;
-                    parameter_idx = parameter_idx - 1;
+                    parameter_idx = parameter_idx + 1;
 
                 }
                 else if ((u3_gate->get_parameter_num() == 1) && u3_gate->is_phi_parameter()) {
                     vartheta = 0;
-                    varphi = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
+                    varphi = std::fmod( parameters_data[parameter_idx], 2*M_PI);
                     varlambda =0;
-                    parameter_idx = parameter_idx - 1;
+                    parameter_idx = parameter_idx + 1;
                 }
                 else if ((u3_gate->get_parameter_num() == 1) && u3_gate->is_lambda_parameter()) {
                     vartheta = 0;
                     varphi =  0;
-                    varlambda = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
-                    parameter_idx = parameter_idx - 1;
+                    varlambda = std::fmod( parameters_data[parameter_idx], 2*M_PI);
+                    parameter_idx = parameter_idx + 1;
                 }
                 else if ((u3_gate->get_parameter_num() == 2) && u3_gate->is_theta_parameter() && u3_gate->is_phi_parameter() ) {
-                    vartheta = std::fmod( 2*parameters_data[parameter_idx-2], 4*M_PI);
-                    varphi = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
+                    vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
+                    varphi = std::fmod( parameters_data[parameter_idx+1], 2*M_PI);
                     varlambda = 0;
-                    parameter_idx = parameter_idx - 2;
+                    parameter_idx = parameter_idx + 2;
                 }
                 else if ((u3_gate->get_parameter_num() == 2) && u3_gate->is_theta_parameter() && u3_gate->is_lambda_parameter() ) {
-                    vartheta = std::fmod( 2*parameters_data[parameter_idx-2], 4*M_PI);
+                    vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
                     varphi = 0;
-                    varlambda = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
-                    parameter_idx = parameter_idx - 2;
+                    varlambda = std::fmod( parameters_data[parameter_idx+1], 2*M_PI);
+                    parameter_idx = parameter_idx + 2;
                 }
                 else if ((u3_gate->get_parameter_num() == 2) && u3_gate->is_phi_parameter() && u3_gate->is_lambda_parameter() ) {
                     vartheta = 0;
-                    varphi = std::fmod( parameters_data[parameter_idx-2], 2*M_PI);
-                    varlambda = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
-                    parameter_idx = parameter_idx - 2;
+                    varphi = std::fmod( parameters_data[parameter_idx], 2*M_PI);
+                    varlambda = std::fmod( parameters_data[parameter_idx+1], 2*M_PI);
+                    parameter_idx = parameter_idx + 2;
                 }
                 else if ((u3_gate->get_parameter_num() == 3)) {
-                    vartheta = std::fmod( 2*parameters_data[parameter_idx-3], 4*M_PI);
-                    varphi = std::fmod( parameters_data[parameter_idx-2], 2*M_PI);
-                    varlambda = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
-                    parameter_idx = parameter_idx - 3;
+                    vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
+                    varphi = std::fmod( parameters_data[parameter_idx+1], 2*M_PI);
+                    varlambda = std::fmod( parameters_data[parameter_idx+2], 2*M_PI);
+                    parameter_idx = parameter_idx + 3;
                 }
 
 //                message = message + "U3 on target qubit %d with parameters theta = %f, phi = %f and lambda = %f";
@@ -1755,8 +1755,8 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
                 double vartheta;
                 // get the inverse parameters of the U3 rotation
                 RX* rx_gate = static_cast<RX*>(gate);		
-                vartheta = std::fmod( 2*parameters_data[parameter_idx-1], 4*M_PI);
-                parameter_idx = parameter_idx - 1;
+                vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
+                parameter_idx = parameter_idx + 1;
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: RX on target qubit: " << rx_gate->get_target_qbit() << " and with parameters theta = " << vartheta << std::endl;
@@ -1768,8 +1768,8 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
                 double vartheta;
                 // get the inverse parameters of the U3 rotation
                 RY* ry_gate = static_cast<RY*>(gate);
-                vartheta = std::fmod( 2*parameters_data[parameter_idx-1], 4*M_PI);
-                parameter_idx = parameter_idx - 1;
+                vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
+                parameter_idx = parameter_idx + 1;
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: RY on target qubit: " << ry_gate->get_target_qbit() << " and with parameters theta = " << vartheta << std::endl; 
@@ -1781,8 +1781,8 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
                 double vartheta;
                 // get the inverse parameters of the U3 rotation
                 CRY* cry_gate = static_cast<CRY*>(gate);
-                vartheta = std::fmod( 2*parameters_data[parameter_idx-1], 4*M_PI);
-                parameter_idx = parameter_idx - 1;
+                vartheta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
+                parameter_idx = parameter_idx + 1;
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: CRY on target qubit: " << cry_gate->get_target_qbit() << ", control qubit" << cry_gate->get_control_qbit() << " and with parameters theta = " << vartheta << std::endl;
@@ -1794,8 +1794,8 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
                 double varphi;
                 // get the inverse parameters of the U3 rotation
                 RZ* rz_gate = static_cast<RZ*>(gate);
-                varphi = std::fmod( 2*parameters_data[parameter_idx-1], 2*M_PI);
-                parameter_idx = parameter_idx - 1;
+                varphi = std::fmod( 2*parameters_data[parameter_idx], 2*M_PI);
+                parameter_idx = parameter_idx + 1;
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: RZ on target qubit: " << rz_gate->get_target_qbit() << " and with parameters varphi = " << varphi << std::endl;
@@ -1845,13 +1845,13 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
             }
             else if (gate->get_type() == BLOCK_OPERATION) {
                 Gates_block* block_gate = static_cast<Gates_block*>(gate);
-                const Matrix_real parameters_layer(parameters.get_data() + parameter_idx - gate->get_parameter_num(), 1, gate->get_parameter_num() );
+                const Matrix_real parameters_layer(parameters.get_data() + parameter_idx, 1, gate->get_parameter_num() );
                 block_gate->list_gates( parameters_layer, gate_idx );
-                parameter_idx = parameter_idx - block_gate->get_parameter_num();
+                parameter_idx = parameter_idx + block_gate->get_parameter_num();
                 gate_idx = gate_idx + block_gate->get_gate_num();
             }
             else if (gate->get_type() == UN_OPERATION) {
-                parameter_idx = parameter_idx - gate->get_parameter_num();
+                parameter_idx = parameter_idx + gate->get_parameter_num();
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: UN " << gate->get_parameter_num() << " parameters" << std::endl;
@@ -1863,8 +1863,8 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
                 double Theta;
                 // get the inverse parameters of the U3 rotation
                 CZ_NU* cz_nu_gate = static_cast<CZ_NU*>(gate);
-                Theta = std::fmod( parameters_data[parameter_idx-1], 2*M_PI);
-                parameter_idx = parameter_idx - 1;
+                Theta = std::fmod( parameters_data[parameter_idx], 2*M_PI);
+                parameter_idx = parameter_idx +1;
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: CZ_NU gate on target qubit: " << cz_nu_gate->get_target_qbit() << ", control qubit " << cz_nu_gate->get_control_qbit() << " and with parameters Theta = " << Theta << std::endl;
@@ -1891,8 +1891,8 @@ void Gates_block::list_gates( const Matrix_real &parameters, int start_index ) {
                 double Theta;
                 // get the inverse parameters of the U3 rotation
                 Adaptive* ad_gate = static_cast<Adaptive*>(gate);
-                Theta = std::fmod( 2*parameters_data[parameter_idx-1], 4*M_PI);
-                parameter_idx = parameter_idx - 1;
+                Theta = std::fmod( 2*parameters_data[parameter_idx], 4*M_PI);
+                parameter_idx = parameter_idx + 1;
 
 		std::stringstream sstream;
 		sstream << gate_idx << "th gate: Adaptive gate on target qubit: " << ad_gate->get_target_qbit() << ", control qubit " << ad_gate->get_control_qbit() << " and with parameters Theta = " << Theta << std::endl;


### PR DESCRIPTION
List gates was still operating with the old reversed parameter order. 