### PR TITLE
Add pybind11 dependency and fix NumPy include discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,25 @@ endif()
 
 message("Include paths: " ${CMAKE_REQUIRED_INCLUDES})
 
-set(NUMPY_INC_DIR ${NumPy_INCLUDE_DIR})
+# Prefer NumPy headers from the active PYTHON_EXECUTABLE. FindNumPy can resolve to
+# a stale system path such as /usr/include -> python3.9 numpy 1.x while the env
+# runs NumPy 2.x, which then fails at import with ABI/_ARRAY_API errors.
+execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
+    OUTPUT_VARIABLE NUMPY_INC_DIR_FROM_PYTHON
+    RESULT_VARIABLE NUMPY_GET_INCLUDE_FAILED
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT NUMPY_GET_INCLUDE_FAILED AND NOT "${NUMPY_INC_DIR_FROM_PYTHON}" STREQUAL "")
+    set(NUMPY_INC_DIR ${NUMPY_INC_DIR_FROM_PYTHON})
+    message(STATUS "Using NumPy include from PYTHON_EXECUTABLE: ${NUMPY_INC_DIR}")
+else()
+    set(NUMPY_INC_DIR ${NumPy_INCLUDE_DIR})
+    message(STATUS "Using NumPy include from FindNumPy: ${NUMPY_INC_DIR}")
+endif()
 
 
-if(NOT NumPy_FOUND)
+if(NOT NumPy_FOUND AND NUMPY_GET_INCLUDE_FAILED)
     message(FATAL_ERROR "NumPy headers not found")
 endif()
 

--- a/conda_env_example.yaml
+++ b/conda_env_example.yaml
@@ -15,6 +15,7 @@ dependencies:
   - scikit-build
   - numpy
   - scipy
+  - pybind11
   - tbb-devel
   - pip:
       - gurobipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "numpy",
     "scipy",
     "networkx",
+    "pybind11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Add `pybind11` to project dependencies and the example conda environment so density-matrix bindings can build.
- Prefer NumPy headers from the active Python interpreter in CMake to avoid ABI mismatches from stale system includes (`/usr/include` NumPy 1.x vs env NumPy 2.x).

## Test plan
- [ ] Create/update `qgd` env with `conda_env_example.yaml` (or `conda install -n qgd -c conda-forge pybind11`)
- [ ] Clean rebuild: `python setup.py build_ext` and confirm density-matrix configure finds pybind11
- [ ] `import squander` succeeds against current NumPy
- [ ] Confirm `_density_matrix_cpp` extension is produced under `squander/density_matrix/`

Made with [Cursor](https://cursor.com)