### PR TITLE
Accumulate wall-clock circuit simulation time in batched cost evaluat…

### DIFF
--- a/squander/src-cpp/decomposition/Optimization_Interface.cpp
+++ b/squander/src-cpp/decomposition/Optimization_Interface.cpp
@@ -36,6 +36,7 @@ limitations under the License.
 
 #include <fstream>
 #include <tbb/enumerable_thread_specific.h>
+#include <tbb/tick_count.h>
 
 extern "C" int LAPACKE_dgesv( 	int  matrix_layout, int n, int nrhs, double *a, int lda, int *ipiv, double *b, int ldb); 	
 
@@ -938,17 +939,19 @@ Optimization_Interface::optimization_problem_batched_Groq( std::vector<Matrix_re
 Matrix_real 
 Optimization_Interface::optimization_problem_batched( std::vector<Matrix_real>& parameters_vec) {
 
+    tbb::tick_count t0_circuit_simulation = tbb::tick_count::now();
 
-
-
-             
 #if defined __DFE__
     if ( Umtx.cols == Umtx.rows && get_accelerator_num() > 0 ) {
-        return optimization_problem_batched_DFE( parameters_vec );
+        Matrix_real cost_fnc_mtx = optimization_problem_batched_DFE( parameters_vec );
+        circuit_simulation_time += (tbb::tick_count::now() - t0_circuit_simulation).seconds();
+        return cost_fnc_mtx;
     }
 #elif defined __GROQ__
     if ( Umtx.cols == 1 && get_accelerator_num() > 0 ) {
-        return optimization_problem_batched_Groq( parameters_vec );
+        Matrix_real cost_fnc_mtx = optimization_problem_batched_Groq( parameters_vec );
+        circuit_simulation_time += (tbb::tick_count::now() - t0_circuit_simulation).seconds();
+        return cost_fnc_mtx;
     }
 #endif 
 
@@ -1023,8 +1026,8 @@ Optimization_Interface::optimization_problem_batched( std::vector<Matrix_real>& 
 
 
 #endif  // __MPI__
-       
-     
+
+    circuit_simulation_time += (tbb::tick_count::now() - t0_circuit_simulation).seconds();
     return cost_fnc_mtx;
         
 }

--- a/squander/src-cpp/decomposition/include/Optimization_Interface.h
+++ b/squander/src-cpp/decomposition/include/Optimization_Interface.h
@@ -111,9 +111,9 @@ protected:
     int trace_offset;
 
 
-    /// Time spent on circuit simulation/cost function evaluation
+    /// Time spent on circuit simulation/cost function evaluation [seconds]
     double circuit_simulation_time;
-    /// time spent on optimization
+    /// Time spent on optimization [seconds]
     double CPU_time;    
 
 

--- a/squander/src-cpp/optimization_engines/AGENTS.cpp
+++ b/squander/src-cpp/optimization_engines/AGENTS.cpp
@@ -870,8 +870,8 @@ exit(-1);
 
                 if ( iter_idx % agent_lifetime_loc == 0 && agent_idx == 0) {
                     std::stringstream sstream;
-                    sstream << "AGENTS, agent " << agent_idx << ": processed iterations " << (double)iter_idx/max_inner_iterations_loc*100 << "%";
-                    sstream << ", current minimum of agent 0: " << current_minimum_agents[ 0 ] << " global current minimum: " << current_minimum  << " CPU time: " << CPU_time;
+                    sstream << "AGENTS " << ": processed iterations " << (double)iter_idx/max_inner_iterations_loc*100 << "%";
+                    sstream << ", global current minimum: " << current_minimum  << " CPU time on optimization logic: " << CPU_time;
                     sstream << " circuit simulation time: " << circuit_simulation_time  << std::endl;
                     print(sstream, 3); 
                 }


### PR DESCRIPTION
## Summary
- Measure and accumulate `circuit_simulation_time` as wall-clock seconds once per `optimization_problem_batched` call (CPU, DFE, and Groq paths).
- Clarify that `circuit_simulation_time` and `CPU_time` are reported in seconds.
- Tidy AGENTS progress logging so it reports optimization CPU time and circuit simulation time clearly.
## Test plan
- [ ] Rebuild with the `qgd` environment and run an AGENTS-based optimization that prints progress at agent lifetime intervals
- [ ] Confirm `circuit simulation time` increases roughly with wall-clock duration of batched cost evaluations (not ~N× wall time under parallel batches)
- [ ] Confirm `CPU time on optimization logic` still advances separately from circuit simulation time
EOF