### PR TITLE
Fix GitHub Release creation in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -386,6 +386,7 @@ jobs:
       - name: Create GitHub Release
         run: |
           gh release create "v${{ needs.get-version.outputs.version }}" \
+            --repo "${{ github.repository }}" \
             --title "Release v${{ needs.get-version.outputs.version }}" \
             --notes "## Release v${{ needs.get-version.outputs.version }}
           


### PR DESCRIPTION
## Summary
- Pass `--repo "${{ github.repository }}"` to `gh release create` in the publish job
- Avoids `fatal: not a git repository` when the job only downloads wheel artifacts and never checks out the repo

## Test plan
- [ ] Re-run the publish workflow (PyPI target) and confirm the Create GitHub Release step succeeds
- [ ] Verify the created release tag/title/notes match the published version


Made with [Cursor](https://cursor.com)